### PR TITLE
Joomla 3 EOL Security Fixes PR 9

### DIFF
--- a/administrator/components/com_media/controllers/file.php
+++ b/administrator/components/com_media/controllers/file.php
@@ -115,6 +115,21 @@ class MediaControllerFile extends JControllerLegacy
 			// Make the filename safe
 			$file['name'] = JFile::makeSafe($file['name']);
 
+			/**
+			 * SECURITY PATCH: CVE-2025-22213
+			 * Added January 2026 by N8 Solutions
+			 */
+			// Strictly prevent upload of executable PHP or system extensions
+			$ext = strtolower(JFile::getExt($file['name']));
+			$forbidden = array('php', 'phtml', 'php5', 'php7', 'php8', 'phps', 'shtml', 'pl', 'py', 'cgi', 'asp', 'aspx');
+			
+			if (in_array($ext, $forbidden))
+			{
+			    $this->setMessage(JText::_('COM_MEDIA_ERROR_WARNUPLOADTYPE'), 'error');
+			    return false;
+			}
+			/** END N8 SOLUTIONS SECURITY PATCH **/
+
 			// We need a url safe name
 			$fileparts = pathinfo(COM_MEDIA_BASE . '/' . $this->folder . '/' . $file['name']);
 

--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,10 @@
       },
       {
         "type": "vcs",
+        "url": "https://github.com/NielBuys/j3_filter"
+      },
+      {
+        "type": "vcs",
         "url": "https://github.com/NielBuys/JoomlaApplication.git"
       }
     ],

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6546cc06aa6ee9779b369f6709f70347",
+    "content-hash": "6d3040ae15f7da4da345ce6ba18c2c6a",
     "packages": [
         {
             "name": "google/recaptcha",
@@ -514,12 +514,12 @@
             "version": "1.4.7",
             "source": {
                 "type": "git",
-                "url": "https://github.com/joomla-framework/filter.git",
+                "url": "https://github.com/NielBuys/j3_filter.git",
                 "reference": "156c03c2cc620086ce12bd912f7a0b757884ddde"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/joomla-framework/filter/zipball/156c03c2cc620086ce12bd912f7a0b757884ddde",
+                "url": "https://api.github.com/repos/NielBuys/j3_filter/zipball/156c03c2cc620086ce12bd912f7a0b757884ddde",
                 "reference": "156c03c2cc620086ce12bd912f7a0b757884ddde",
                 "shasum": ""
             },
@@ -546,7 +546,11 @@
                     "Joomla\\Filter\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "Joomla\\Filter\\Tests\\": "Tests/"
+                }
+            },
             "license": [
                 "GPL-2.0-or-later"
             ],
@@ -558,19 +562,8 @@
                 "joomla"
             ],
             "support": {
-                "issues": "https://github.com/joomla-framework/filter/issues",
-                "source": "https://github.com/joomla-framework/filter/tree/1.4.7"
+                "source": "https://github.com/NielBuys/j3_filter/tree/1.4.7"
             },
-            "funding": [
-                {
-                    "url": "https://community.joomla.org/sponsorship-campaigns.html",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/joomla",
-                    "type": "github"
-                }
-            ],
             "time": "2024-08-20T15:36:53+00:00"
         },
         {

--- a/libraries/joomla/database/driver.php
+++ b/libraries/joomla/database/driver.php
@@ -1951,36 +1951,37 @@ abstract class JDatabaseDriver extends JDatabase implements JDatabaseInterface
 	 */
 	protected function quoteNameStr($strArr)
 	{
-		$q = $this->nameQuote;
-		$parts = [];
+	    $q = $this->nameQuote;
+	    $parts = array();
+	    $strArr = (array) $strArr;
 
-		// Ensure $strArr is an array
-		$strArr = (array) $strArr;
-
-		foreach ($strArr as $part)
-		{
-			if (is_null($part) || $part === '')
-			{
-				continue;
-			}
-
-			// Strip control characters and null bytes
-			$part = preg_replace('/[\x00-\x1F\x7F]/u', '', $part);
-
-			// Strip any existing name quotes to prevent double escaping
-			if (is_array($q))
-			{
-				$part = str_replace([$q[0], $q[1]], '', $part);
-				$parts[] = $q[0] . $part . $q[1];
-			}
-			else
-			{
-				$part = str_replace($q, '', $part);
-				$parts[] = $q . $part . $q;
-			}
+	    foreach ($strArr as $part)
+	    {
+		if (is_null($part) || $part === '') {
+		    continue;
 		}
 
-		return implode('.', $parts);
+		// 1. BLOCK: CVE-2025-25226 - Reject if suspicious
+		if (strpos($part, "\x00") !== false || strpos($part, '\\') !== false)
+		{
+		    throw new InvalidArgumentException('Invalid database identifier.');
+		}
+
+		// 2. CLEAN: Your control character logic (Good for PHP 8.5/Strict)
+		$part = preg_replace('/[\x00-\x1F\x7F]/u', '', $part);
+
+		// 3. ESCAPE: Use the PR's doubling logic (Standard SQL behavior)
+		if (strlen($q) == 1)
+		{
+		    $parts[] = $q . str_replace($q, $q . $q, $part) . $q;
+		}
+		else
+		{
+		    $parts[] = $q[0] . str_replace($q[1], $q[1] . $q[1], $part) . $q[1];
+		}
+	    }
+
+	    return implode('.', $parts);
 	}
 
 	/**

--- a/libraries/src/Helper/ModuleHelper.php
+++ b/libraries/src/Helper/ModuleHelper.php
@@ -249,6 +249,20 @@ abstract class ModuleHelper
 			return '';
 		}
 
+		/**
+		 * SECURITY PATCH: CVE-2024-40747
+		 * Added January 2026 by N8 Solutions
+		 * Ensure module chrome attributes are escaped to prevent XSS.
+		 */
+		foreach ($attribs as $key => $value)
+		{
+			if (is_string($value))
+			{
+				$attribs[$key] = htmlspecialchars($value, ENT_QUOTES, 'UTF-8');
+			}
+		}
+		/** END N8 SOLUTIONS SECURITY PATCH **/
+
 		foreach (explode(' ', $attribs['style']) as $style)
 		{
 			$chromeMethod = 'modChrome_' . $style;

--- a/libraries/vendor/composer/installed.php
+++ b/libraries/vendor/composer/installed.php
@@ -1,9 +1,9 @@
 <?php return array(
     'root' => array(
         'name' => 'joomla/joomla-cms',
-        'pretty_version' => 'dev-master',
-        'version' => 'dev-master',
-        'reference' => '05e278ce398dcfcf048caaaae134d7907da71da3',
+        'pretty_version' => 'dev-3.10-dev',
+        'version' => 'dev-3.10-dev',
+        'reference' => 'e75aefdbf78094b4bee44497909c024977c3b8fc',
         'type' => 'project',
         'install_path' => __DIR__ . '/../../../',
         'aliases' => array(),
@@ -137,9 +137,9 @@
             'dev_requirement' => false,
         ),
         'joomla/joomla-cms' => array(
-            'pretty_version' => 'dev-master',
-            'version' => 'dev-master',
-            'reference' => '05e278ce398dcfcf048caaaae134d7907da71da3',
+            'pretty_version' => 'dev-3.10-dev',
+            'version' => 'dev-3.10-dev',
+            'reference' => 'e75aefdbf78094b4bee44497909c024977c3b8fc',
             'type' => 'project',
             'install_path' => __DIR__ . '/../../../',
             'aliases' => array(),

--- a/libraries/vendor/joomla/filter/src/InputFilter.php
+++ b/libraries/vendor/joomla/filter/src/InputFilter.php
@@ -325,8 +325,24 @@ class InputFilter
 		$attrSubSet[0] = strtolower($attrSubSet[0]);
 		$attrSubSet[1] = html_entity_decode(strtolower($attrSubSet[1]), $quoteStyle, 'UTF-8');
 
-		// Remove common XSS-evasion characters
-		$attrSubSet[1] = str_replace(["\t", "\n", " ", "\0"], "", $attrSubSet[1]);
+		/**
+		 * SECURITY PATCH: CVE-2025-54476 & CVE-2025-63082
+		 * Added January 2026 by N8 Solutions (Backported from Joomla 5.x)
+		 */
+		
+		// 1. Strip hidden control characters to prevent filter bypass (CVE-2025-54476)
+		$attrSubSet[1] = preg_replace('/[\x00-\x1F\x7F-\x9F]/u', '', $attrSubSet[1]);
+
+		// 2. Block malicious Data URLs that could contain XSS payloads (CVE-2025-63082)
+		if (stripos($attrSubSet[1], 'data:') === 0)
+		{
+			// Only allow safe image base64 patterns. Reject all others.
+			if (!preg_match('/^data:image\/(png|gif|jpe?g|webp);base64,/i', $attrSubSet[1]))
+			{
+				return true; 
+			}
+		}
+		/** END N8 SOLUTIONS SECURITY PATCH **/
 
 		return (strpos($attrSubSet[1], 'expression') !== false && $attrSubSet[0] === 'style')
 			|| preg_match('/(?:(?:java|vb|live)script|behaviour|mocha)(?::|&colon;|&column;)/', $attrSubSet[1]) !== 0;

--- a/plugins/content/pagebreak/pagebreak.php
+++ b/plugins/content/pagebreak/pagebreak.php
@@ -286,7 +286,13 @@ class PlgContentPagebreak extends JPlugin
 		$this->list[1]->liClass = ($limitstart === 0 && $showall === 0) ? 'toclink active' : 'toclink';
 		$this->list[1]->class   = $this->list[1]->liClass;
 		$this->list[1]->link    = JRoute::_(ContentHelperRoute::getArticleRoute($row->slug, $row->catid, $row->language));
-		$this->list[1]->title   = $heading;
+		
+		/**
+		 * SECURITY PATCH: CVE-2025-63083
+		 * Added January 2026 by N8 Solutions
+		 */
+		$this->list[1]->title   = htmlspecialchars($heading, ENT_QUOTES, 'UTF-8');
+		/** END N8 SOLUTIONS SECURITY PATCH **/
 
 		$i = 2;
 
@@ -298,11 +304,11 @@ class PlgContentPagebreak extends JPlugin
 
 				if (@$attrs2['alt'])
 				{
-					$title = stripslashes($attrs2['alt']);
+					$title = (string) $attrs2['alt'];
 				}
 				elseif (@$attrs2['title'])
 				{
-					$title = stripslashes($attrs2['title']);
+					$title = (string) $attrs2['title'];
 				}
 				else
 				{
@@ -316,7 +322,14 @@ class PlgContentPagebreak extends JPlugin
 
 			$this->list[$i]          = new stdClass;
 			$this->list[$i]->link    = JRoute::_(ContentHelperRoute::getArticleRoute($row->slug, $row->catid, $row->language) . '&limitstart=' . ($i - 1));
-			$this->list[$i]->title   = $title;
+			
+			/**
+			 * SECURITY PATCH: CVE-2025-63083
+			 * Added January 2026 by N8 Solutions
+			 */
+			$this->list[$i]->title   = htmlspecialchars($title, ENT_QUOTES, 'UTF-8');
+			/** END N8 SOLUTIONS SECURITY PATCH **/
+			
 			$this->list[$i]->liClass = ($limitstart === $i - 1) ? 'active' : '';
 			$this->list[$i]->class   = ($limitstart === $i - 1) ? 'toclink active' : 'toclink';
 


### PR DESCRIPTION
Adding: https://github.com/TLWebdesign/Joomla-3-EOL-Security-Fixes/pull/9

https://github.com/advisories/GHSA-fr9h-7cq2-wq74 (Pagebreak XSS)
https://github.com/advisories/GHSA-w359-ppwg-hrqh (Input Filter Data URL hardening)
https://github.com/advisories/GHSA-44v2-prcf-pc3m (Database Driver SQLi protection)
https://github.com/advisories/GHSA-3qqq-rj9x-fp8h (Media Manager upload hardening)
https://github.com/advisories/GHSA-c3p9-p32w-9r8m (Module Helper chrome attribute escaping)
